### PR TITLE
separate activeState and stateMachine logic

### DIFF
--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -242,12 +242,29 @@ func TestProcessAST(t *testing.T) {
 				{"100", "2"},
 			},
 		},
-		{ // index 17
+		{ // index 18
 			TemplateFilePath: "/../../testfiles/16.txt",
 			SourceFilePath:   "/../../testfiles/src16.txt",
 			ExpectedHeader:   []string{"FirstValue", "SecondValue"},
 			ExpectedRows: [][]interface{}{
 				{"100", "2"},
+			},
+		},
+		{ // index 19
+			TemplateFilePath: "/../../testfiles/17.txt",
+			SourceFilePath:   "/../../testfiles/src17.txt",
+			ExpectedHeader:   []string{"neighbor", "ASN", "NGROUP", "DESC", "RPIN", "RPOUT"},
+			ExpectedRows: [][]interface{}{
+				{"192.168.74.22", "", "INERNALCPE", "INTERNAL:CPE:ROUTEREFLECTOR", "", ""},
+				{"192.168.74.23", "", "INERNALCPE", "INTERNAL:CPE:ROUTEREFLECTOR", "", ""},
+				{"192.168.74.24", "", "INERNALCPE", "INTERNAL:CPE:ROUTEREFLECTOR", "", ""},
+				{"192.168.74.25", "", "INERNALCPE", "INTERNAL:CPE:ROUTEREFLECTOR", "", ""},
+				{"172.31.255.11", "", "EXTERNALBLUE", "EXTERNAL:CPE:ROUTEREFLECTOR", "reject", "reject"},
+				{"1.1.1.1", "808", "808HAWAII", "EXTERNAL:CUSTOMER:808", "", ""},
+				{"2.2.2.2", "", "1299TT", "FULLROUTES:TT", "", "TT"},
+				{"19.12.12.1", "", "19NG", "INTERNAL:ROUTES:VPN", "reject-some", "reject-them"},
+				{"32.12.12.12", "9999", "BLACKHOLE", "EXTERNAL:SERVICEVPN:100", "", ""},
+				{"23.23.23.23", "9082", "23S-policy", "EXTERNAL:SERVICEVPN:200", "", ""},
 			},
 		},
 	}

--- a/testfiles/17.txt
+++ b/testfiles/17.txt
@@ -1,0 +1,24 @@
+Value neighbor (\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b)
+Value ASN (\d+)
+Value NGROUP (\S+)
+Value DESC (\S+)
+Value RPIN (\S+)
+Value RPOUT (\S+)
+
+Start
+  ^router bgp.* -> BGP
+
+BGP
+  ^.*neighbor ${neighbor}.* -> NEIGH
+
+NEIGH
+  ^.*remote-as ${ASN}
+  ^.*use neighbor-group ${NGROUP}
+  ^.*description ${DESC}
+  ^.*address-family ipv4 unicast -> AFI4UNI
+  ^.*! -> Record BGP
+
+AFI4UNI
+  ^.*route-policy ${RPIN} in
+  ^.*route-policy ${RPOUT} out
+  ^.*! -> Record BGP

--- a/testfiles/src17.txt
+++ b/testfiles/src17.txt
@@ -1,0 +1,74 @@
+
+router bgp 65115
+ bgp router-id 127.0.0.1
+ !
+ neighbor-group INTERNAL_CABLE_MODEMS
+  remote-as 65513
+  update-source Loopback1
+  graceful-restart
+  address-family ipv4 unicast
+   route-policy all in
+   route-policy all out
+   next-hop-self
+  !
+ neighbor-group SOME-policy
+  use neighbor-group SHOULD_NEVER_SEE
+  !
+ !
+ neighbor 192.168.74.22
+  use neighbor-group INERNALCPE
+  description INTERNAL:CPE:ROUTEREFLECTOR
+ !
+ neighbor 192.168.74.23
+  use neighbor-group INERNALCPE
+  description INTERNAL:CPE:ROUTEREFLECTOR
+ !
+ neighbor 192.168.74.24
+  use neighbor-group INERNALCPE
+  description INTERNAL:CPE:ROUTEREFLECTOR
+ !
+ neighbor 192.168.74.25
+  use neighbor-group INERNALCPE
+  description INTERNAL:CPE:ROUTEREFLECTOR
+ !
+ neighbor 172.31.255.11
+  use neighbor-group EXTERNALBLUE
+  description EXTERNAL:CPE:ROUTEREFLECTOR
+  address-family ipv4 unicast
+   route-policy reject in
+   route-policy reject out
+  !
+ !
+ neighbor 1.1.1.1
+  remote-as 808
+  use neighbor-group 808HAWAII
+  description EXTERNAL:CUSTOMER:808
+ !
+ neighbor 2.2.2.2
+  use neighbor-group 1299TT
+  description FULLROUTES:TT
+  address-family ipv4 unicast
+   route-policy TT out
+  !
+ !
+  !
+ neighbor 19.12.12.1
+  use neighbor-group 19NG
+  description INTERNAL:ROUTES:VPN
+  address-family ipv4 unicast
+   route-policy reject-some in
+   route-policy reject-them out
+  !
+ !
+ neighbor 32.12.12.12
+  remote-as 9999
+  use neighbor-group BLACKHOLE
+  description EXTERNAL:SERVICEVPN:100
+ !
+ neighbor 23.23.23.23
+  remote-as 9082
+  use neighbor-group 23S-policy
+  description EXTERNAL:SERVICEVPN:200
+  address-family ipv4 unicast
+  !
+ !


### PR DESCRIPTION
this is a fix for #33 .

in this pr, we separate `activeState` from ``stateMachine`, 

`activeState` while hold the active `record`, while `stateMachine` provide the `processCommands` to process the source lines in the respective state.